### PR TITLE
use BUILD to trigger parsing on object creation rather than wrapping new

### DIFF
--- a/lib/MySQL/Workbench/Parser/Column.pm
+++ b/lib/MySQL/Workbench/Parser/Column.pm
@@ -26,14 +26,10 @@ has table => (
     },
 );
 
-around new => sub {
-    my ($code,$class,@arg) = @_;
-
-    my $obj = $code->($class, @arg);
-    $obj->_parse;
-
-    return $obj;
-};
+sub BUILD {
+    my $self = shift;
+    $self->_parse;
+}
 
 has name          => ( is => 'rwp' );
 has id            => ( is => 'rwp' );

--- a/lib/MySQL/Workbench/Parser/Index.pm
+++ b/lib/MySQL/Workbench/Parser/Index.pm
@@ -26,14 +26,10 @@ has table => (
     },
 );
 
-around new => sub {
-    my ($code,$class,@arg) = @_;
-
-    my $obj = $code->($class, @arg);
-    $obj->_parse;
-
-    return $obj;
-};
+sub BUILD {
+    my $self = shift;
+    $self->_parse;
+}
 
 has id   => ( is => 'rwp' );
 has name => ( is => 'rwp' );

--- a/lib/MySQL/Workbench/Parser/Table.pm
+++ b/lib/MySQL/Workbench/Parser/Table.pm
@@ -86,14 +86,10 @@ has column_mapping => (
     },
 );
 
-around new => sub {
-    my ($code,$class,@arg) = @_;
-
-    my $obj = $code->($class, @arg);
-    $obj->_parse;
-
-    return $obj;
-};
+sub BUILD {
+    my $self = shift;
+    $self->_parse;
+}
 
 =head2 as_hash
 


### PR DESCRIPTION
Wrapping new is not generally supported by Moo, and future versions of
Moo will start issuing errors in some cases where it causes problems.
The supported mechanism for running code after the object has been
constructed is a BUILD sub, so use that instead.
