### PR TITLE
Add initial GitHub Actions workflow for Linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,30 @@
+name: linux
+
+on: [push, pull_request]
+
+jobs:
+  perl_tester:
+    runs-on: 'ubuntu-latest'
+    name: "perl v${{ matrix.perl-version }}"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version:
+          - "5.32"
+          - "5.30"
+          - "5.28"
+          - "5.26"
+          - "5.24"
+          - "5.22"
+          - "5.20"
+
+    container:
+      image: perldocker/perl-tester:${{ matrix.perl-version }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: cpanm --notest Dist::Zilla || { cat ~/.cpanm/build.log ; false ; }
+      - run: dzil authordeps --missing | cpanm || { cat ~/.cpanm/build.log ; false ; }
+      - run: dzil listdeps --author --missing | cpanm || { cat ~/.cpanm/build.log ; false ; }
+      - run: dzil smoke --author --release


### PR DESCRIPTION
This PR adds an initial GitHub Actions workflow for Linux so that it can reproduce the current test behaviour as that used in the TravisCI configuration.

Note that `Dist::Zilla` requires a minimum of Perl 5.20, hence the list
of Perls begins at this version.  The remainder of the list matches that
in the TravisCI config.

@reneeb: if this change is accepted, do you want me to remove the TravisCI configuration?  It seems that TravisCI isn't very friendly to open source projects anymore...