### PR TITLE
Bump copyright year to current year

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,7 @@ name    = MySQL-Workbench-Parser
 author  = Renee Baecker <reneeb@cpan.org>
 license = Artistic_2_0
 copyright_holder = Renee Baecker
-copyright_year   = 2018
+copyright_year   = 2021
 
 [PodCoverageTests]
 [PodSyntaxTests]


### PR DESCRIPTION
I'm going to assume that the next release of the dist will be this year,
hence I've chosen to set the year to the current year.

I notice, however, that the most recent release of the dist is in 2020, so please let me know if you'd prefer to use that year instead.