### PR TITLE
Fix podchecker warnings

### DIFF
--- a/lib/MySQL/Workbench/Parser.pm
+++ b/lib/MySQL/Workbench/Parser.pm
@@ -253,6 +253,17 @@ __END__
 
 =head1 SYNOPSIS
 
+    # create the parser
+    my $parser = MySQL::Workbench::Parser->new(
+        file => '/path/to/file.mwb',
+    );
+
+    # access tables of the workbench ER model
+    my @tables = @{ $parser->tables };
+
+    # access views of the workbench ER model
+    my @views = @{ $parser->views };
+
 =head1 DESCRIPTION
 
 The MySQL Workbench is a tool to design database entity relationship models.

--- a/lib/MySQL/Workbench/Parser/MySQLParser.pm
+++ b/lib/MySQL/Workbench/Parser/MySQLParser.pm
@@ -1250,7 +1250,13 @@ SQL::Translator
 
 =head2 normalize_field
 
+Takes a field as argument and normalizes it in place.
+
 =head2 parse
+
+Parses input data (as a string) using the given SQL::Translator instance.
+This method is called as C<$class::parse($transator, $data_as_string)>.  See
+L<SQL::Translator::Parser> for more information.
 
 =head1 AUTHOR
 

--- a/lib/MySQL/Workbench/Parser/Table.pm
+++ b/lib/MySQL/Workbench/Parser/Table.pm
@@ -97,6 +97,8 @@ sub BUILD {
     $self->_parse;
 }
 
+=head1 METHODS
+
 =head2 as_hash
 
 return info about a table as a hash

--- a/lib/MySQL/Workbench/Parser/View.pm
+++ b/lib/MySQL/Workbench/Parser/View.pm
@@ -91,6 +91,8 @@ sub BUILD {
     $self->_parse;
 }
 
+=head1 METHODS
+
 =head2 as_hash
 
 return info about a view as a hash


### PR DESCRIPTION
I noticed that `podchecker` threw up a few warnings about empty sections and missing preceding higher level headings.  This PR addresses the underlying issues which these warnings pointed to.

I wasn't 100% sure if I got the content of the `SYNOPSIS` section of the main module right; please let me know if anything needs to be changed.  If so, I'm more than happy to update the code and resubmit the PR.